### PR TITLE
fix a bug of undefined Alphabet.toks

### DIFF
--- a/esm/data.py
+++ b/esm/data.py
@@ -126,7 +126,7 @@ class Alphabet(object):
         return self.all_toks[ind]
 
     def to_dict(self):
-        return {"toks": self.toks}
+        return {"toks": self.standard_toks}
 
     def get_batch_converter(self):
         if self.use_msa:

--- a/esm/data.py
+++ b/esm/data.py
@@ -126,17 +126,13 @@ class Alphabet(object):
         return self.all_toks[ind]
 
     def to_dict(self):
-        return {"toks": self.standard_toks}
+        return self.tok_to_idx.copy()
 
     def get_batch_converter(self):
         if self.use_msa:
             return MSABatchConverter(self)
         else:
             return BatchConverter(self)
-
-    @classmethod
-    def from_dict(cls, d, **kwargs):
-        return cls(standard_toks=d["toks"], **kwargs)
 
     @classmethod
     def from_architecture(cls, name: str) -> "Alphabet":


### PR DESCRIPTION
Fix error attribute 'toks' into 'standard_toks'

```Traceback (most recent call last):
  File "/home/xxx/test_esm.py", line 11, in <module>
    print(model_alphabet.to_dict())
  File "/home/xxx/anaconda3/envs/fasthit/lib/python3.9/site-packages/fair_esm-0.3.1-py3.9.egg/esm/data.py", line 129, in to_dict
AttributeError: 'Alphabet' object has no attribute 'toks'
```