### PR TITLE
Fix: Use mutation-col option in variant-prediction/predict.py

### DIFF
--- a/variant-prediction/predict.py
+++ b/variant-prediction/predict.py
@@ -163,7 +163,7 @@ def main(args):
             token_probs = torch.cat(all_token_probs, dim=0).unsqueeze(0)
             df[model_location] = df.apply(
                 lambda row: label_row(
-                    row["mutant"], args.sequence, token_probs, alphabet, args.offset_idx
+                    row[args.mutation_col], args.sequence, token_probs, alphabet, args.offset_idx
                 ),
                 axis=1,
             )
@@ -179,7 +179,7 @@ def main(args):
                     token_probs = torch.log_softmax(model(batch_tokens.cuda())["logits"], dim=-1)
                 df[model_location] = df.apply(
                     lambda row: label_row(
-                        row["mutant"], args.sequence, token_probs, alphabet, args.offset_idx
+                        row[args.mutation_col], args.sequence, token_probs, alphabet, args.offset_idx
                     ),
                     axis=1,
                 )
@@ -196,7 +196,7 @@ def main(args):
                 token_probs = torch.cat(all_token_probs, dim=0).unsqueeze(0)
                 df[model_location] = df.apply(
                     lambda row: label_row(
-                        row["mutant"], args.sequence, token_probs, alphabet, args.offset_idx
+                        row[args.mutation_col], args.sequence, token_probs, alphabet, args.offset_idx
                     ),
                     axis=1,
                 )
@@ -204,7 +204,7 @@ def main(args):
                 tqdm.pandas()
                 df[model_location] = df.progress_apply(
                     lambda row: compute_pppl(
-                        row["mutant"], args.sequence, model, alphabet, args.offset_idx
+                        row[args.mutation_col], args.sequence, model, alphabet, args.offset_idx
                     ),
                     axis=1,
                 )


### PR DESCRIPTION
The `mutation-col` argument was defined but not used in the script `variant-prediction/predict.py`. This PR fixed it.