### PR TITLE
Update torch-hub load to point to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ We also support PyTorch Hub, which removes the need to clone and/or install this
 
 ```python
 import torch
-model, alphabet = torch.hub.load("facebookresearch/esm", "esm1b_t33_650M_UR50S")
+model, alphabet = torch.hub.load("facebookresearch/esm:main", "esm1b_t33_650M_UR50S")
 ```
 
 Then, you can load and use a pretrained model as follows:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -16,7 +16,7 @@ import esm
 def test_readme_1():
     import torch
 
-    model, alphabet = torch.hub.load("facebookresearch/esm", "esm1b_t33_650M_UR50S")
+    model, alphabet = torch.hub.load("facebookresearch/esm:main", "esm1b_t33_650M_UR50S")
 
 
 def test_readme_2():


### PR DESCRIPTION
Now that the primary branch is called `main`, torch.hub calls must explicitly reference the main branch

In the README, this should be
```
model, alphabet = torch.hub.load("facebookresearch/esm:main", "esm1b_t33_650M_UR50S")
```

Reference:
https://stackoverflow.com/questions/69349308/torch-hub-load-raises-httperror-http-error-404-not-found-when-loading-model