### PR TITLE
Fix data leakage in CV in variant prediction example

### DIFF
--- a/examples/sup_variant_prediction.ipynb
+++ b/examples/sup_variant_prediction.ipynb
@@ -95,9 +95,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import sys\n",
-    "# PATH_TO_REPO = \"../\"\n",
-    "# sys.path.append(PATH_TO_REPO)"
+    "import sys\n",
+    "PATH_TO_REPO = \"../\"\n",
+    "sys.path.append(PATH_TO_REPO)"
    ]
   },
   {
@@ -132,7 +132,8 @@
     "from sklearn.svm import SVC, SVR\n",
     "from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor\n",
     "from sklearn.naive_bayes import GaussianNB\n",
-    "from sklearn.linear_model import LogisticRegression, SGDRegressor"
+    "from sklearn.linear_model import LogisticRegression, SGDRegressor\n",
+    "from sklearn.pipeline import Pipeline"
    ]
   },
   {
@@ -233,7 +234,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pca = PCA(60)\n",
+    "num_pca_components = 60\n",
+    "pca = PCA(num_pca_components)\n",
     "Xs_train_pca = pca.fit_transform(Xs_train)"
    ]
   },
@@ -292,28 +294,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "knn_grid = {\n",
-    "    'n_neighbors': [5, 10],\n",
-    "    'weights': ['uniform', 'distance'],\n",
-    "    'algorithm': ['ball_tree', 'kd_tree', 'brute'],\n",
-    "    'leaf_size' : [15, 30],\n",
-    "    'p' : [1, 2],\n",
-    "}\n",
+    "knn_grid = [\n",
+    "    {\n",
+    "        'model': [KNeighborsRegressor()],\n",
+    "        'model__n_neighbors': [5, 10],\n",
+    "        'model__weights': ['uniform', 'distance'],\n",
+    "        'model__algorithm': ['ball_tree', 'kd_tree', 'brute'],\n",
+    "        'model__leaf_size' : [15, 30],\n",
+    "        'model__p' : [1, 2],\n",
+    "    }\n",
+    "    ]\n",
     "\n",
-    "svm_grid = {\n",
-    "    'C' : [0.1, 1.0, 10.0],\n",
-    "    'kernel' :['linear', 'poly', 'rbf', 'sigmoid'],\n",
-    "    'degree' : [3],\n",
-    "    'gamma': ['scale'],\n",
-    "}\n",
+    "svm_grid = [\n",
+    "    {\n",
+    "        'model': [SVR()],\n",
+    "        'model__C' : [0.1, 1.0, 10.0],\n",
+    "        'model__kernel' : ['linear', 'poly', 'rbf', 'sigmoid'],\n",
+    "        'model__degree' : [3],\n",
+    "        'model__gamma': ['scale'],\n",
+    "    }\n",
+    "]\n",
     "\n",
-    "rfr_grid = {\n",
-    "    'n_estimators' : [20],\n",
-    "    'criterion' : ['mse', 'mae'],\n",
-    "    'max_features': ['sqrt', 'log2'],\n",
-    "    'min_samples_split' : [5, 10],\n",
-    "    'min_samples_leaf': [1, 4]\n",
-    "}"
+    "rfr_grid = [\n",
+    "    {\n",
+    "        'model': [RandomForestRegressor()],\n",
+    "        'model__n_estimators' : [20],\n",
+    "        'model__criterion' : ['squared_error', 'absolute_error'],\n",
+    "        'model__max_features': ['sqrt', 'log2'],\n",
+    "        'model__min_samples_split' : [5, 10],\n",
+    "        'model__min_samples_leaf': [1, 4]\n",
+    "    }\n",
+    "]"
    ]
   },
   {
@@ -341,18 +352,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# make sure data preprocessing (PCA here) is run inside CV to avoid data leakage\n",
+    "pipe = Pipeline(steps=(('pca', PCA(num_pca_components), ('model', 'passthrough')))\n",
+    "\n",
     "result_list = []\n",
     "grid_list = []\n",
     "for cls_name, param_grid in zip(cls_list, param_grid_list):\n",
     "    print(cls_name)\n",
     "    grid = GridSearchCV(\n",
-    "        estimator = cls_name(), \n",
+    "        estimator = pipe,\n",
     "        param_grid = param_grid,\n",
     "        scoring = 'r2',\n",
     "        verbose = 1,\n",
     "        n_jobs = -1 # use all available cores\n",
     "    )\n",
-    "    grid.fit(Xs_train_pca, ys_train)\n",
+    "    grid.fit(Xs_train, ys_train)\n",
     "    result_list.append(pd.DataFrame.from_dict(grid.cv_results_))\n",
     "    grid_list.append(grid)"
    ]
@@ -396,7 +410,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_list[1].sort_values('rank_test_score')"
+    "result_list[1].sort_values('rank_test_score')[:5]"
    ]
   },
   {
@@ -433,11 +447,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Xs_test_pca = pca.transform(Xs_test)\n",
     "for grid in grid_list:\n",
-    "    print(grid.best_estimator_)\n",
+    "    print(grid.best_estimator_.get_params()[\"steps\"][1][1]) # get the model details from the estimator\n",
     "    print()\n",
-    "    preds = grid.predict(Xs_test_pca)\n",
+    "    preds = grid.predict(Xs_test)\n",
     "    print(f'{scipy.stats.spearmanr(ys_test, preds)}')\n",
     "    print('\\n', '-' * 80, '\\n')\n"
    ]
@@ -479,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the variant prediction example notebook esm/examples/sup_variant_prediction.ipynb the top 60 principal components are selected and used to reduce the dimensionality of the training set. By doing this before running CV there is data leakage into the cross-validation sets. [(https://github.com/facebookresearch/esm/discussions/140)]

This PR pushes the selection of the principal components to inside the CV step.