### PR TITLE
add ESM-1v bibtex file for easy citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The MSA Transformer (ESM-MSA-1) can improve performance further by leveraging MS
 </details>
 
 <details><summary>Table of contents</summary>
-  
+
 - [Main models you should use](#main-models)
 - [Comparison to related works](#perf_related)
 - [Usage](#usage)
@@ -39,7 +39,7 @@ The MSA Transformer (ESM-MSA-1) can improve performance further by leveraging MS
 </details>
 
 <details><summary>What's New</summary>
-  
+
 - August 2021: Added flexibility to tokenizer to allow for spaces and special tokens (like `<mask>`) in sequence.
 - July 2021: New pre-trained model ESM-1v released, trained on UniRef90 (see [Meier et al. 2021](https://doi.org/10.1101/2021.07.09.450648)).
 - July 2021: New MSA Transformer released, with a minor fix in the row positional embeddings (`ESM-MSA-1b`).
@@ -47,7 +47,7 @@ The MSA Transformer (ESM-MSA-1) can improve performance further by leveraging MS
 - Dec 2020: [Self-Attention Contacts](#notebooks) for all pre-trained models (see [Rao et al. 2020](https://doi.org/10.1101/2020.12.15.422761))
 - Dec 2020: Added new pre-trained model [ESM-1b](#perf_related) (see [Rives et al. 2019](https://doi.org/10.1101/622803) Appendix B)
 - Dec 2020: [ESM Structural Split Dataset](#available-esmssd) (see [Rives et al. 2019](https://doi.org/10.1101/622803) Appendix A.10)
-  
+
 </details>
 
 ## Main models you should use <a name="main-models"></a>
@@ -185,7 +185,7 @@ Comparison to related protein language models on structure prediction tasks.
 
 * All contact numbers are the top-L,LR precision metric, where long range means sequence separation of at least 24 residues
 * For unsupervised contact prediction, a sparse linear combination of the attention heads is used to directly predict protein contacts,
-fitted with logistic regression on 20 structures. 
+fitted with logistic regression on 20 structures.
 For more details on the method, see [Rao et al. 2020](https://doi.org/10.1101/2020.12.15.422761).
 * Supervised contact prediction all uses the same resnet (32 layers) and trRosetta training data, cf [Rao et al. 2021](https://www.biorxiv.org/content/10.1101/2021.02.12.430858v2).
 * (SSP) Secondary structure Q8 accuracy on CB513, transformer finetuned with convolution + LSTM head.
@@ -267,15 +267,15 @@ Directory `examples/some_proteins_emb_esm1b/` now contains one `.pt` file per FA
 * `--include` specifies what embeddings to save. You can use the following:
   * `per_tok` includes the full sequence, with an embedding per amino acid (seq_len x hidden_dim).
   * `mean` includes the embeddings averaged over the full sequence, per layer.
-  * `bos` includes the embeddings from the beginning-of-sequence token. 
+  * `bos` includes the embeddings from the beginning-of-sequence token.
   (NOTE: Don't use with the pre-trained models - we trained without bos-token supervision)
 
 ### Zero-shot variant prediction <a name="zs_variant"></a>
-See "[./variant-prediction/](variant-prediction/)" for code and pre-trained weights for the ESM-1v models described in 
+See "[./variant-prediction/](variant-prediction/)" for code and pre-trained weights for the ESM-1v models described in
 [Language models enable zero-shot prediction of the effects of mutations on protein function. (Meier et al. 2021)](https://doi.org/10.1101/2021.07.09.450648).
 
 
-### Notebooks <a name="notebooks"></a> 
+### Notebooks <a name="notebooks"></a>
 
 #### Supervised variant prediction - training a classifier on the embeddings
 
@@ -305,7 +305,7 @@ that is without any supervised training.**
 
 This [jupyter notebook tutorial](examples/contact_prediction.ipynb) demonstrates contact prediction with both the ESM-1b and MSA Transformer (ESM-MSA-1) models.
 Contact prediction is based on a logistic regression over the model's attention maps.
-This methodology is based on our ICLR 2021 paper, 
+This methodology is based on our ICLR 2021 paper,
 [Transformer protein language models are unsupervised structure learners. (Rao et al. 2020)](https://doi.org/10.1101/2020.12.15.422761)
 The MSA Transformer (ESM-MSA-1) takes a multiple sequence alignment (MSA) as input, and uses the tied row self-attention maps in the same way.
 See [MSA Transformer. (Rao et al. 2021)](https://www.biorxiv.org/content/10.1101/2021.02.12.430858v1).
@@ -358,19 +358,19 @@ train and test sets. For a given classification level each structure appears in 
 in the cross validation experiment each of the structures will be evaluated exactly once.
 
 The dataset provides 3d coordinates, distance maps, and secondary structure labels.
-For further details on the construction of the dataset 
+For further details on the construction of the dataset
 see [Rives et al. 2019](https://doi.org/10.1101/622803) Appendix A.10.
 
 This [jupyter notebook tutorial](examples/esm_structural_dataset.ipynb) shows how to load and index the `ESMStructuralSplitDataset`.
 
-`ESMStructuralSplitDataset`, upon initializing, will download `splits` and `pkl`. 
+`ESMStructuralSplitDataset`, upon initializing, will download `splits` and `pkl`.
 We also provide `msas` for each of the domains. The data can be directly downloaded below.
 
 | Name   | Description                                                                   | URL                                                                   |
 |--------|-------------------------------------------------------------------------------|-----------------------------------------------------------------------|
 | splits | train/valid splits                                                            | https://dl.fbaipublicfiles.com/fair-esm/structural-data/splits.tar.gz |
 | pkl    | pkl objects containing sequence, SSP labels, distance map, and 3d coordinates | https://dl.fbaipublicfiles.com/fair-esm/structural-data/pkl.tar.gz    |
-| msas   | a3m files containing MSA for each domain                                      | https://dl.fbaipublicfiles.com/fair-esm/structural-data/msas.tar.gz   | 
+| msas   | a3m files containing MSA for each domain                                      | https://dl.fbaipublicfiles.com/fair-esm/structural-data/msas.tar.gz   |
 
 ### Pre-training Dataset Split  <a name="available-pretraining-split"></a>
 The split files establishing which UniRef50 clusters were used as held-out evaluation set for pre-training
@@ -395,7 +395,7 @@ If you find the models useful in your research, we ask that you cite the relevan
   journal={bioRxiv}
 }
 ```
- 
+
 For the self-attention contact prediction:
 
 ```bibtex
@@ -436,6 +436,12 @@ For variant prediction using ESM-1v:
 ```
 
 Much of this code builds on the [fairseq](https://github.com/pytorch/fairseq) sequence modeling framework. We use fairseq internally for our protein language modeling research. We highly recommend trying it out if you'd like to pre-train protein language models from scratch.
+
+Additionally, if you would like to use the variant prediction benchmark from Meier et al. (2021), we provide a bibtex file with citations for all data in [variant-prediction/mutation_data.bib](variant-prediction/mutation_data.bib). You can cite each paper individually, or add all citations in bulk using the LaTeX command:
+
+```tex
+\nocite{wrenbeck2017deep,klesmith2015comprehensive,haddox2018mapping,romero2015dissecting,firnberg2014comprehensive,deng2012deep,stiffler2015evolvability,jacquier2013capturing,findlay2018comprehensive,mclaughlin2012spatial,kitzman2015massively,doud2016accurate,pokusaeva2019experimental,mishra2016systematic,kelsic2016rna,melnikov2014comprehensive,brenan2016phenotypic,rockah2015systematic,wu2015functional,aakre2015evolving,qi2014quantitative,matreyek2018multiplex,bandaru2017deconstruction,roscoe2013analyses,roscoe2014systematic,mavor2016determination,chan2017correlation,melamed2013deep,starita2013activity,araya2012fundamental}
+```
 
 ## License <a name="license"></a>
 

--- a/variant-prediction/mutation_data.bib
+++ b/variant-prediction/mutation_data.bib
@@ -1,0 +1,294 @@
+@article{wrenbeck2017deep,
+  title={Deep sequencing methods for protein engineering and design},
+  author={Wrenbeck, Emily E and Faber, Matthew S and Whitehead, Timothy A},
+  journal={Current opinion in structural biology},
+  volume={45},
+  pages={36--44},
+  year={2017},
+  publisher={Elsevier}
+}
+@article{klesmith2015comprehensive,
+  title={Comprehensive sequence-flux mapping of a levoglucosan utilization pathway in E. coli},
+  author={Klesmith, Justin R and Bacik, John-Paul and Michalczyk, Ryszard and Whitehead, Timothy A},
+  journal={ACS synthetic biology},
+  volume={4},
+  number={11},
+  pages={1235--1243},
+  year={2015},
+  publisher={ACS Publications}
+}
+@article{haddox2018mapping,
+  title={Mapping mutational effects along the evolutionary landscape of HIV envelope},
+  author={Haddox, Hugh K and Dingens, Adam S and Hilton, Sarah K and Overbaugh, Julie and Bloom, Jesse D},
+  journal={Elife},
+  volume={7},
+  pages={e34420},
+  year={2018},
+  publisher={eLife Sciences Publications Limited}
+}
+@article{romero2015dissecting,
+  title={Dissecting enzyme function with microfluidic-based deep mutational scanning},
+  author={Romero, Philip A and Tran, Tuan M and Abate, Adam R},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={112},
+  number={23},
+  pages={7159--7164},
+  year={2015},
+  publisher={National Acad Sciences}
+}
+@article{firnberg2014comprehensive,
+  title={A comprehensive, high-resolution map of a gene’s fitness landscape},
+  author={Firnberg, Elad and Labonte, Jason W and Gray, Jeffrey J and Ostermeier, Marc},
+  journal={Molecular biology and evolution},
+  volume={31},
+  number={6},
+  pages={1581--1592},
+  year={2014},
+  publisher={Oxford University Press}
+}
+@article{deng2012deep,
+  title={Deep sequencing of systematic combinatorial libraries reveals $\beta$-lactamase sequence constraints at high resolution},
+  author={Deng, Zhifeng and Huang, Wanzhi and Bakkalbasi, Erol and Brown, Nicholas G and Adamski, Carolyn J and Rice, Kacie and Muzny, Donna and Gibbs, Richard A and Palzkill, Timothy},
+  journal={Journal of molecular biology},
+  volume={424},
+  number={3-4},
+  pages={150--167},
+  year={2012},
+  publisher={Elsevier}
+}
+@article{stiffler2015evolvability,
+  title={Evolvability as a function of purifying selection in TEM-1 $\beta$-lactamase},
+  author={Stiffler, Michael A and Hekstra, Doeke R and Ranganathan, Rama},
+  journal={Cell},
+  volume={160},
+  number={5},
+  pages={882--892},
+  year={2015},
+  publisher={Elsevier}
+}
+@article{jacquier2013capturing,
+  title={Capturing the mutational landscape of the beta-lactamase TEM-1},
+  author={Jacquier, Herv{\'e} and Birgy, Andr{\'e} and Le Nagard, Herv{\'e} and Mechulam, Yves and Schmitt, Emmanuelle and Glodt, J{\'e}r{\'e}my and Bercot, Beatrice and Petit, Emmanuelle and Poulain, Julie and Barnaud, Guil{\`e}ne and others},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={110},
+  number={32},
+  pages={13067--13072},
+  year={2013},
+  publisher={National Acad Sciences}
+}
+@article{findlay2018comprehensive,
+  title={Comprehensive characterization of transcript diversity at the human NODAL locus},
+  author={Findlay, Scott D and Postovit, Lynne-Marie},
+  journal={BioRxiv},
+  pages={254409},
+  year={2018},
+  publisher={Cold Spring Harbor Laboratory}
+}
+@article{mclaughlin2012spatial,
+  title={The spatial architecture of protein function and adaptation},
+  author={McLaughlin Jr, Richard N and Poelwijk, Frank J and Raman, Arjun and Gosal, Walraj S and Ranganathan, Rama},
+  journal={Nature},
+  volume={491},
+  number={7422},
+  pages={138--142},
+  year={2012},
+  publisher={Nature Publishing Group}
+}
+@article{kitzman2015massively,
+  title={Massively parallel single-amino-acid mutagenesis},
+  author={Kitzman, Jacob O and Starita, Lea M and Lo, Russell S and Fields, Stanley and Shendure, Jay},
+  journal={Nature methods},
+  volume={12},
+  number={3},
+  pages={203--206},
+  year={2015},
+  publisher={Nature Publishing Group}
+}
+@article{doud2016accurate,
+  title={Accurate measurement of the effects of all amino-acid mutations on influenza hemagglutinin},
+  author={Doud, Michael B and Bloom, Jesse D},
+  journal={Viruses},
+  volume={8},
+  number={6},
+  pages={155},
+  year={2016},
+  publisher={Multidisciplinary Digital Publishing Institute}
+}
+@article{pokusaeva2019experimental,
+  title={An experimental assay of the interactions of amino acids from orthologous sequences shaping a complex fitness landscape},
+  author={Pokusaeva, Victoria O and Usmanova, Dinara R and Putintseva, Ekaterina V and Espinar, Lorena and Sarkisyan, Karen S and Mishin, Alexander S and Bogatyreva, Natalya S and Ivankov, Dmitry N and Akopyan, Arseniy V and Avvakumov, Sergey Ya and others},
+  journal={PLoS genetics},
+  volume={15},
+  number={4},
+  pages={e1008079},
+  year={2019},
+  publisher={Public Library of Science San Francisco, CA USA}
+}
+@article{mishra2016systematic,
+  title={Systematic mutant analyses elucidate general and client-specific aspects of Hsp90 function},
+  author={Mishra, Parul and Flynn, Julia M and Starr, Tyler N and Bolon, Daniel NA},
+  journal={Cell reports},
+  volume={15},
+  number={3},
+  pages={588--598},
+  year={2016},
+  publisher={Elsevier}
+}
+@article{kelsic2016rna,
+  title={RNA structural determinants of optimal codons revealed by MAGE-Seq},
+  author={Kelsic, Eric D and Chung, Hattie and Cohen, Niv and Park, Jimin and Wang, Harris H and Kishony, Roy},
+  journal={Cell systems},
+  volume={3},
+  number={6},
+  pages={563--571},
+  year={2016},
+  publisher={Elsevier}
+}
+@article{melnikov2014comprehensive,
+  title={Comprehensive mutational scanning of a kinase in vivo reveals substrate-dependent fitness landscapes},
+  author={Melnikov, Alexandre and Rogov, Peter and Wang, Li and Gnirke, Andreas and Mikkelsen, Tarjei S},
+  journal={Nucleic acids research},
+  volume={42},
+  number={14},
+  pages={e112--e112},
+  year={2014},
+  publisher={Oxford University Press}
+}
+@article{brenan2016phenotypic,
+  title={Phenotypic characterization of a comprehensive set of MAPK1/ERK2 missense mutants},
+  author={Brenan, Lisa and Andreev, Aleksandr and Cohen, Ofir and Pantel, Sasha and Kamburov, Atanas and Cacchiarelli, Davide and Persky, Nicole S and Zhu, Cong and Bagul, Mukta and Goetz, Eva M and others},
+  journal={Cell reports},
+  volume={17},
+  number={4},
+  pages={1171--1183},
+  year={2016},
+  publisher={Elsevier}
+}
+@article{rockah2015systematic,
+  title={Systematic mapping of protein mutational space by prolonged drift reveals the deleterious effects of seemingly neutral mutations},
+  author={Rockah-Shmuel, Liat and T{\'o}th-Petr{\'o}czy, {\'A}gnes and Tawfik, Dan S},
+  journal={PLoS computational biology},
+  volume={11},
+  number={8},
+  pages={e1004421},
+  year={2015},
+  publisher={Public Library of Science San Francisco, CA USA}
+}
+@article{wu2015functional,
+  title={Functional constraint profiling of a viral protein reveals discordance of evolutionary conservation and functionality},
+  author={Wu, Nicholas C and Olson, C Anders and Du, Yushen and Le, Shuai and Tran, Kevin and Remenyi, Roland and Gong, Danyang and Al-Mawsawi, Laith Q and Qi, Hangfei and Wu, Ting-Ting and others},
+  journal={PLoS genetics},
+  volume={11},
+  number={7},
+  pages={e1005310},
+  year={2015},
+  publisher={Public Library of Science San Francisco, CA USA}
+}
+@article{aakre2015evolving,
+  title={Evolving new protein-protein interaction specificity through promiscuous intermediates},
+  author={Aakre, Christopher D and Herrou, Julien and Phung, Tuyen N and Perchuk, Barrett S and Crosson, Sean and Laub, Michael T},
+  journal={Cell},
+  volume={163},
+  number={3},
+  pages={594--606},
+  year={2015},
+  publisher={Elsevier}
+}
+@article{qi2014quantitative,
+  title={A quantitative high-resolution genetic profile rapidly identifies sequence determinants of hepatitis C viral fitness and drug sensitivity},
+  author={Qi, Hangfei and Olson, C Anders and Wu, Nicholas C and Ke, Ruian and Loverdo, Claude and Chu, Virginia and Truong, Shawna and Remenyi, Roland and Chen, Zugen and Du, Yushen and others},
+  journal={PLoS pathogens},
+  volume={10},
+  number={4},
+  pages={e1004064},
+  year={2014},
+  publisher={Public Library of Science San Francisco, USA}
+}
+@article{matreyek2018multiplex,
+  title={Multiplex assessment of protein variant abundance by massively parallel sequencing},
+  author={Matreyek, Kenneth A and Starita, Lea M and Stephany, Jason J and Martin, Beth and Chiasson, Melissa A and Gray, Vanessa E and Kircher, Martin and Khechaduri, Arineh and Dines, Jennifer N and Hause, Ronald J and others},
+  journal={Nature genetics},
+  volume={50},
+  number={6},
+  pages={874--882},
+  year={2018},
+  publisher={Nature Publishing Group}
+}
+@article{bandaru2017deconstruction,
+  title={Deconstruction of the Ras switching cycle through saturation mutagenesis},
+  author={Bandaru, Pradeep and Shah, Neel H and Bhattacharyya, Moitrayee and Barton, John P and Kondo, Yasushi and Cofsky, Joshua C and Gee, Christine L and Chakraborty, Arup K and Kortemme, Tanja and Ranganathan, Rama and others},
+  journal={Elife},
+  volume={6},
+  pages={e27810},
+  year={2017},
+  publisher={eLife Sciences Publications Limited}
+}
+@article{roscoe2013analyses,
+  title={Analyses of the effects of all ubiquitin point mutants on yeast growth rate},
+  author={Roscoe, Benjamin P and Thayer, Kelly M and Zeldovich, Konstantin B and Fushman, David and Bolon, Daniel NA},
+  journal={Journal of molecular biology},
+  volume={425},
+  number={8},
+  pages={1363--1377},
+  year={2013},
+  publisher={Elsevier}
+}
+@article{roscoe2014systematic,
+  title={Systematic exploration of ubiquitin sequence, E1 activation efficiency, and experimental fitness in yeast},
+  author={Roscoe, Benjamin P and Bolon, Daniel NA},
+  journal={Journal of molecular biology},
+  volume={426},
+  number={15},
+  pages={2854--2870},
+  year={2014},
+  publisher={Elsevier}
+}
+@article{mavor2016determination,
+  title={Determination of ubiquitin fitness landscapes under different chemical stresses in a classroom setting},
+  author={Mavor, David and Barlow, Kyle and Thompson, Samuel and Barad, Benjamin A and Bonny, Alain R and Cario, Clinton L and Gaskins, Garrett and Liu, Zairan and Deming, Laura and Axen, Seth D and others},
+  journal={Elife},
+  volume={5},
+  pages={e15802},
+  year={2016},
+  publisher={eLife Sciences Publications Limited}
+}
+@article{chan2017correlation,
+  title={Correlation of fitness landscapes from three orthologous TIM barrels originates from sequence and structure constraints},
+  author={Chan, Yvonne H and Venev, Sergey V and Zeldovich, Konstantin B and Matthews, C Robert},
+  journal={Nature communications},
+  volume={8},
+  number={1},
+  pages={1--12},
+  year={2017},
+  publisher={Nature Publishing Group}
+}
+@article{melamed2013deep,
+  title={Deep mutational scanning of an RRM domain of the Saccharomyces cerevisiae poly (A)-binding protein},
+  author={Melamed, Daniel and Young, David L and Gamble, Caitlin E and Miller, Christina R and Fields, Stanley},
+  journal={Rna},
+  volume={19},
+  number={11},
+  pages={1537--1551},
+  year={2013},
+  publisher={Cold Spring Harbor Lab}
+}
+@article{starita2013activity,
+  title={Activity-enhancing mutations in an E3 ubiquitin ligase identified by high-throughput mutagenesis},
+  author={Starita, Lea M and Pruneda, Jonathan N and Lo, Russell S and Fowler, Douglas M and Kim, Helen J and Hiatt, Joseph B and Shendure, Jay and Brzovic, Peter S and Fields, Stanley and Klevit, Rachel E},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={110},
+  number={14},
+  pages={E1263--E1272},
+  year={2013},
+  publisher={National Acad Sciences}
+}
+@article{araya2012fundamental,
+  title={A fundamental protein property, thermodynamic stability, revealed solely from large-scale measurements of protein function},
+  author={Araya, Carlos L and Fowler, Douglas M and Chen, Wentao and Muniez, Ike and Kelly, Jeffery W and Fields, Stanley},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={109},
+  number={42},
+  pages={16858--16863},
+  year={2012},
+  publisher={National Acad Sciences}
+}


### PR DESCRIPTION
Adds a bibtex file under `variant_prediction` with citations for all the DMS studies used in the benchmark. Also adds a latex command using `\nocite` for automatically adding all citations to a paper.