### PR TITLE
Avoid torch-geometric dependency by skipping esm.inverse_folding by default

### DIFF
--- a/esm/__init__.py
+++ b/esm/__init__.py
@@ -8,4 +8,3 @@ from .version import version as __version__  # noqa
 from .data import Alphabet, BatchConverter, FastaBatchedDataset  # noqa
 from .model import ProteinBertModel, MSATransformer  # noqa
 from . import pretrained  # noqa
-from . import inverse_folding # noqa

--- a/esm/pretrained.py
+++ b/esm/pretrained.py
@@ -74,6 +74,7 @@ def has_emb_layer_norm_before(model_state):
 
 
 def load_model_and_alphabet_core(model_data, regression_data=None):
+    import esm  # conditional esm.inverse_folding below
     if regression_data is not None:
         model_data["model"].update(regression_data["model"])
 
@@ -118,6 +119,7 @@ def load_model_and_alphabet_core(model_data, regression_data=None):
         model_type = esm.MSATransformer
 
     elif "invariant_gvp" in model_data["args"].arch:
+        import esm.inverse_folding
         model_type = esm.inverse_folding.gvp_transformer.GVPTransformerModel 
         model_args = vars(model_data["args"]) # convert Namespace -> dict
 

--- a/examples/inverse_folding/README.md
+++ b/examples/inverse_folding/README.md
@@ -97,7 +97,7 @@ be of shape L x 3 x 3, where L is the number of amino acids in the structure.
 To load a structure from PDB and mmCIF file formats and extract the backbone
 coordinates of the N, CA, C atoms as model input,
 ```
-import esm
+import esm.inverse_folding
 structure = esm.inverse_folding.util.load_structure(fpath, chain_id)
 coords, seq = esm.inverse_folding.util.extract_coords_from_structure(structure)
 ```
@@ -127,7 +127,7 @@ recovery, we recommend sampling with low temperature such as `T=1e-6`.
 To score the conditional log-likelihoods for sequences conditioned on a given
 set of backbone coordinates, use the `score_sequence` function,
 ```
-import esm
+import esm.inverse_folding
 ll_fullseq, ll_withcoord = esm.inverse_folding.util.score_sequence(model, alphabet, coords, seq)
 ```
 

--- a/examples/inverse_folding/sample_sequences.py
+++ b/examples/inverse_folding/sample_sequences.py
@@ -13,6 +13,7 @@ import numpy as np
 from pathlib import Path
 
 import esm
+import esm.inverse_folding
 
 
 def main():

--- a/examples/inverse_folding/score_log_likelihoods.py
+++ b/examples/inverse_folding/score_log_likelihoods.py
@@ -17,6 +17,7 @@ import torch.nn.functional as F
 from tqdm import tqdm
 
 import esm
+import esm.inverse_folding
 
 
 def main():

--- a/tests/test_inverse_folding.py
+++ b/tests/test_inverse_folding.py
@@ -8,6 +8,7 @@ def test_esm_if1():
     import torch
     
     import esm
+    import esm.inverse_folding
 
     example_file = Path(__file__).absolute().parent / "inverse_folding_test_example.json"
     with open(example_file) as f:


### PR DESCRIPTION
We want to avoid having torch-geometric as dependency for all of esm.
We achieve this here by skipping esm.inverse_folding by default on `import esm`.
As a consequence, we need to `import esm.inverse_folding` explicitly