### PR TITLE
ignore esm/dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 *.egg-info/
 .ipynb_checkpoints/
 .vscode/
+esm/dev
 
 # Junk #
 ########


### PR DESCRIPTION
not a symlink for now, but this allows the symlink without reporting "untracked content"