### PR TITLE
Changed the way we get the parameters' device for fsdp

### DIFF
--- a/esm/modules.py
+++ b/esm/modules.py
@@ -348,7 +348,7 @@ class ContactPredictionHead(nn.Module):
 
         # features: B x C x T x T
         attentions = attentions.to(
-            next(self.parameters())
+            self.regression.weight.device
         )  # attentions always float32, may need to convert to float16
         attentions = apc(symmetrize(attentions))
         attentions = attentions.permute(0, 2, 3, 1)


### PR DESCRIPTION
Currently if we want to get the device of the parameters of a module, we do:
`next(self.parameters()).device`

However this is not possible if the model is FSDP-wrapped, since FSDP removes all parameters from `self._parameters` and `next(self.parameters()).device` will only get a StopIteration error.

The goal is to get the device in a way that whether the model is FSDP-wrapped, we can get the correct device.