### PR TITLE
Fix the bash commands in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ As a prerequisite, you must have PyTorch installed to use this repository.
 You can use this one-liner for installation, using the latest release of esm:
 
 ```bash
-$ pip install fair-esm  # latest release, OR:
-$ pip install git+https://github.com/facebookresearch/esm.git  # bleeding edge, current repo main branch
+pip install fair-esm  # latest release, OR:
+pip install git+https://github.com/facebookresearch/esm.git  # bleeding edge, current repo main branch
 ```
 
 
@@ -300,8 +300,7 @@ A cuda device is optional and will be auto-detected.
 The following command extracts the final-layer embedding for a FASTA file from the ESM-2 model:
 
 ```bash
-$ python scripts/extract.py esm2_t33_650M_UR50D examples/data/some_proteins.fasta examples/data/some_proteins_emb_esm2/ \
-    --repr_layers 0 32 33 --include mean per_tok
+python scripts/extract.py esm2_t33_650M_UR50D examples/data/some_proteins.fasta examples/data/some_proteins_emb_esm2 --repr_layers 0 32 33 --include mean per_tok
 ```
 
 Directory `some_proteins_emb_esm2/` now contains one `.pt` file per FASTA sequence; use `torch.load()` to load them.
@@ -356,9 +355,7 @@ For example, to sample 3 sequence designs for the golgi casein kinase structure
 from January 2022](https://pdb101.rcsb.org/motm/265)), we can run the following
 command from the esm root directory:
 ```
-python examples/inverse_folding/sample_sequences.py examples/inverse_folding/data/5YH2.pdb \
-    --chain C --temperature 1 --num-samples 3 \
-    --outpath examples/inverse_folding/output/sampled_sequences.fasta
+python examples/inverse_folding/sample_sequences.py examples/inverse_folding/data/5YH2.pdb --chain C --temperature 1 --num-samples 3 --outpath examples/inverse_folding/output/sampled_sequences.fasta
 ```
 
 The sampled sequences will be saved in a fasta format to the specified output file.
@@ -377,9 +374,7 @@ For example, to score the sequences in `examples/inverse_folding/data/5YH2_mutat
 according to the structure in `examples/inverse_folding/data/5YH2.pdb`, we can run
 the following command from the esm root directory:
 ```
-python examples/inverse_folding/score_log_likelihoods.py examples/inverse_folding/data/5YH2.pdb \
-    examples/inverse_folding/data/5YH2_mutated_seqs.fasta --chain C \
-    --outpath examples/inverse_folding/output/5YH2_mutated_seqs_scores.csv
+python examples/inverse_folding/score_log_likelihoods.py examples/inverse_folding/data/5YH2.pdb examples/inverse_folding/data/5YH2_mutated_seqs.fasta --chain C --outpath examples/inverse_folding/output/5YH2_mutated_seqs_scores.csv
 ```
 
 The conditional log-likelihoods are saved in a csv format in the specified output path.
@@ -408,8 +403,7 @@ as instructed in the notebook or by running the following:
 
 ```bash
 # Obtain the embeddings
-$ python scripts/extract.py esm1v_t33_650M_UR90S_1 examples/data/P62593.fasta examples/data/P62593_emb_esm1v/ \
-    --repr_layers 33 --include mean
+python scripts/extract.py esm1v_t33_650M_UR90S_1 examples/data/P62593.fasta examples/data/P62593_emb_esm1v --repr_layers 33 --include mean
 ```
 
 Then, follow the remaining instructions in the tutorial. You can also run the tutorial in a [colab notebook](https://colab.research.google.com/github/facebookresearch/esm/blob/main/examples/sup_variant_prediction.ipynb).

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ A cuda device is optional and will be auto-detected.
 The following command extracts the final-layer embedding for a FASTA file from the ESM-2 model:
 
 ```bash
-python scripts/extract.py esm2_t33_650M_UR50D examples/data/some_proteins.fasta examples/data/some_proteins_emb_esm2 --repr_layers 0 32 33 --include mean per_tok
+python scripts/extract.py esm2_t33_650M_UR50D examples/data/some_proteins.fasta \
+  examples/data/some_proteins_emb_esm2 --repr_layers 0 32 33 --include mean per_tok
 ```
 
 Directory `some_proteins_emb_esm2/` now contains one `.pt` file per FASTA sequence; use `torch.load()` to load them.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ For example, to sample 3 sequence designs for the golgi casein kinase structure
 from January 2022](https://pdb101.rcsb.org/motm/265)), we can run the following
 command from the esm root directory:
 ```
-python examples/inverse_folding/sample_sequences.py examples/inverse_folding/data/5YH2.pdb --chain C --temperature 1 --num-samples 3 --outpath examples/inverse_folding/output/sampled_sequences.fasta
+python examples/inverse_folding/sample_sequences.py examples/inverse_folding/data/5YH2.pdb \
+  --chain C --temperature 1 --num-samples 3 --outpath examples/inverse_folding/output/sampled_sequences.fasta
 ```
 
 The sampled sequences will be saved in a fasta format to the specified output file.
@@ -375,7 +376,9 @@ For example, to score the sequences in `examples/inverse_folding/data/5YH2_mutat
 according to the structure in `examples/inverse_folding/data/5YH2.pdb`, we can run
 the following command from the esm root directory:
 ```
-python examples/inverse_folding/score_log_likelihoods.py examples/inverse_folding/data/5YH2.pdb examples/inverse_folding/data/5YH2_mutated_seqs.fasta --chain C --outpath examples/inverse_folding/output/5YH2_mutated_seqs_scores.csv
+python examples/inverse_folding/score_log_likelihoods.py examples/inverse_folding/data/5YH2.pdb \ 
+  examples/inverse_folding/data/5YH2_mutated_seqs.fasta --chain C \
+  --outpath examples/inverse_folding/output/5YH2_mutated_seqs_scores.csv
 ```
 
 The conditional log-likelihoods are saved in a csv format in the specified output path.
@@ -404,7 +407,8 @@ as instructed in the notebook or by running the following:
 
 ```bash
 # Obtain the embeddings
-python scripts/extract.py esm1v_t33_650M_UR90S_1 examples/data/P62593.fasta examples/data/P62593_emb_esm1v --repr_layers 33 --include mean
+python scripts/extract.py esm1v_t33_650M_UR90S_1 examples/data/P62593.fasta \
+  examples/data/P62593_emb_esm1v --repr_layers 33 --include mean
 ```
 
 Then, follow the remaining instructions in the tutorial. You can also run the tutorial in a [colab notebook](https://colab.research.google.com/github/facebookresearch/esm/blob/main/examples/sup_variant_prediction.ipynb).


### PR DESCRIPTION
When using the 'copy to clipboard' bash commands are copied
along with the $ symbol, this makes them not ready-to-use.
It also seems that multi lines commands force the user to
manually write them on one line before using them.

Issue: #274 