### PR TITLE
Adjust header in output file

### DIFF
--- a/scripts/esmfold_inference.py
+++ b/scripts/esmfold_inference.py
@@ -179,7 +179,13 @@ if __name__ == "__main__":
         for header, seq, pdb_string, mean_plddt, ptm in zip(
             headers, sequences, pdbs, output["mean_plddt"], output["ptm"]
         ):
-            output_file = args.pdb / f"{header}.pdb"
+            if len(header.split()) > 1:
+                first_elem = header.split()[0]
+                name = '.'.join(first_elem.split('.')[:2])
+            else:
+                name = header
+                        
+            output_file = args.pdb / f"{name}.pdb"
             output_file.write_text(pdb_string)
             num_completed += 1
             logger.info(


### PR DESCRIPTION
From some research, it looked to me that the pertinent part of the name in the header was the "Seita.9G099800" part, so I wanted to split that from the rest. First, see if the header is longer than one element and then isolate the "Seita.9G099800" portion:
```
if len(header.split()) > 1:
                first_elem = header.split()[0]
                name = '.'.join(first_elem.split('.')[:2])
```
If the header is just one word, simply assign the header to the name and put that in the output_file:
```
else:
   name = header

output_file = args.pdb / f"{name}.pdb"
```
Please let me know if this is satisfactory, or if you had something else in mind.