### PR TITLE
Fix link and repeat Atlas license

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bulk download, blog post and the resources provided on the Atlas website are doc
 
 In December 2022, we released two simultaneous preprints on protein design.
 ["Language models generalize beyond natural proteins"](https://doi.org/10.1101/2022.12.21.521521) uses ESM2 to design de novo proteins. The data associated with the preprint can be found in [scripts/design_lm/](scripts/design_lm/).
-["A high-level programming language for generative protein design"](https://doi.org/10.1101/2022.12.21.521521) uses ESMFold to design proteins according to a high-level programming language.
+["A high-level programming language for generative protein design"](https://doi.org/10.1101/2022.12.21.521526) uses ESMFold to design proteins according to a high-level programming language.
 
 
 
@@ -790,3 +790,5 @@ Additionally, if you would like to use the variant prediction benchmark from Mei
 
 This source code is licensed under the MIT license found in the `LICENSE` file
 in the root directory of this source tree.
+
+ESM Metagenomic Atlas (also referred to as “ESM Metagenomic Structure Atlas” or “ESM Atlas”) data is available under a CC BY 4.0 license for academic and commercial use. Copyright (c) Meta Platforms, Inc. All Rights Reserved. Use of the ESM Metagenomic Atlas data is subject to the Meta Open Source [Terms of Use](https://opensource.fb.com/legal/terms/) and [Privacy Policy](https://opensource.fb.com/legal/privacy/).

--- a/scripts/atlas/README.md
+++ b/scripts/atlas/README.md
@@ -85,3 +85,16 @@ If you use any of the ESM Metagenomic Atlas data in your work, please cite
   url={https://doi.org/10.1101/2022.07.20.500902},
 }
 ```
+
+## License <a name="license"></a>
+
+ESM Metagenomic Atlas (also referred to as “ESM Metagenomic Structure Atlas” or “ESM Atlas”) data is available under a CC BY 4.0 license for academic and commercial use. Copyright (c) Meta Platforms, Inc. All Rights Reserved. Use of the ESM Metagenomic Atlas data is subject to the Meta Open Source [Terms of Use](https://opensource.fb.com/legal/terms/) and [Privacy Policy](https://opensource.fb.com/legal/privacy/).
+
+If you make use of a structure predicted by ESMFold, please cite the following paper:
+
+```
+Zeming Lin, Halil Akin, Roshan Rao, Brian Hie, Zhongkai Zhu, Wenting Lu, Nikita Smetanin, Robert Verkuil, Ori Kabeli, Yaniv Shmueli, Allan dos Santos Costa, Maryam Fazel-Zarandi, Tom Sercu, Sal Candido, Alexander Rives.
+Evolutionary-scale prediction of atomic level protein structure with a language model.
+Science 379, 6637 (2023).
+https://www.science.org/doi/abs/10.1126/science.ade2574
+```


### PR DESCRIPTION
Explicitly call out license info. 
Has been documented on https://esmatlas.com/about#license as well as the header of the individual data files.