### PR TITLE
Update util.py

### DIFF
--- a/esm/inverse_folding/util.py
+++ b/esm/inverse_folding/util.py
@@ -134,7 +134,7 @@ def score_sequence(model, alphabet, coords, seq):
 def get_encoder_output(model, alphabet, coords):
     device = next(model.parameters()).device
     batch_converter = CoordBatchConverter(alphabet)
-    batch = [(coords, None, seq)]
+    batch = [(coords, None, None)]
     coords, confidence, strs, tokens, padding_mask = batch_converter(
         batch, device=device)
     encoder_out = model.encoder.forward(coords, padding_mask, confidence,


### PR DESCRIPTION
Hi! This fixes the "NameError: name 'seq' is not defined" error raised when the method `get_encoder_output` is called (this affects ESM-IF1 Colab notebooks provided in the README, where this method or `get_encoder_output_for_complex` is called)