### PR TITLE
Added a basic Dockerfile to improve dev experience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# 11.3.1-base-ubuntu20.04
 FROM nvidia/cuda:11.8.0-base-ubuntu22.04 as base 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# 11.3.1-base-ubuntu20.04
+FROM nvidia/cuda:11.8.0-base-ubuntu22.04 as base 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG C.UTF-8
+
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -qq update \
+    && apt-get -qq install -y gnupg ca-certificates wget git \
+    && apt-get -qq clean \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN  export DEBIAN_FRONTEND=noninteractive \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i cuda-keyring_1.1-1_all.deb \
+    && apt-get -qq update \ 
+    && apt-get install -y --no-install-recommends \
+        cuda-command-line-tools-11-8 \
+        cuda-cudart-dev-11-8 \ 
+        cuda-nvcc-11-8 \
+        cuda-cupti-11-8 \
+        cuda-nvprune-11-8 \
+        cuda-libraries-11-8 \
+        cuda-nvrtc-11-8 \ 
+        libcufft-11-8 \
+        libcurand-11-8 \
+        libcusolver-dev-11-8 \ 
+        libcusparse-dev-11-8 \
+        libcublas-dev-11-8 \
+        libcudnn8=8.6.0.163-1+cuda11.8 \
+        libnvinfer-plugin8=8.6.1.6-1+cuda11.8 \
+        libnvinfer8=8.6.1.6-1+cuda11.8 \
+        build-essential \
+        pkg-config \
+        curl \
+        software-properties-common \
+        unzip \
+    && apt-get -qq clean \
+    && rm -rf /var/lib/apt/lists/* 
+
+RUN find /usr/local/cuda-*/lib*/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete \
+    && rm -f /usr/lib/x86_64-linux-gnu/libcudnn_static_v*.a \ 
+    && ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf \
+    && ldconfig
+
+# Install miniconda
+RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" \
+    && wget --quiet https://repo.continuum.io/miniconda/$MINICONDA \
+    && bash $MINICONDA -b -p /miniconda \
+    && rm -f $MINICONDA
+
+ENV PATH /miniconda/bin:$PATH
+
+COPY environment.yml .
+RUN conda env create -f environment.yml


### PR DESCRIPTION
I made a simple docker container (heavily influenced on the official [Tensorflow docker container](https://github.com/tensorflow/build/blob/master/tensorflow_runtime_dockerfiles/gpu.Dockerfile) that I've used for other deep learning projects, and sharing some of the same features as the official pytorch and openfold containers. I did this mostly because I didn't want to change the version of CUDA and other packages installed on my linux box, and figured this would enable some nice portability for users who I'd imagine are often running ESM in a Docker-based HPC environment like Kubernetes or AWS Batch.

In particular, this container

- Is based off of an NVIDIA CUDA base image (uses CUDA 11.8 though that's compatible with this version of pytorch built against 11.3, providing some forward usability). 
- Uses ubuntu 22. 
- Includes Miniconda, reflecting the environment.yml file included in the repo, and builds that environment.
- Includes the appropriate apt-get packages needed to install esm and openfold. 
- can be easily updated by users looking to work with pytorch or tensorflow since the underlying cuda installation works on both. 


## Build steps
``` bash
 docker build -f Dockerfile -t esm .
```

## Running the container 
``` bash
docker run -it  --rm --runtime=nvidia --gpus all esm
conda activate esmfold
# Whatever else you want to do!
```

I'd be happy to follow up with a `docker-compose.yml` file to further simplify build/usage, and to add some CI/CD automation to add container builds to Github Actions, if of interest. Figured I'd check with the maintainers first to see if this was of interest before continuing though. 

